### PR TITLE
Update PHPDocs & Allow all fort params to be retrieved 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=8",
         "guzzlehttp/guzzle": "^7.4",
-        "laravel/framework": "^9|^10.0"
+        "laravel/framework": "^9|^10.0|^11.0"
     },
     "extra": {
         "laravel": {

--- a/src/PayfortIntegration.php
+++ b/src/PayfortIntegration.php
@@ -2,6 +2,8 @@
 
 namespace TamkeenTech\Payfort;
 
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
+use TamkeenTech\Payfort\Exceptions\RequestFailed;
 use TamkeenTech\Payfort\Services\ApplePayService;
 use TamkeenTech\Payfort\Services\AuthorizePurchaseService;
 use TamkeenTech\Payfort\Services\CaptureService;
@@ -83,7 +85,9 @@ class PayfortIntegration
     }
 
 
-
+    /**
+     * @throws PaymentFailed
+     */
     public function refund($fort_id, $amount)
     {
         return app(RefundService::class)
@@ -94,6 +98,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws PaymentFailed
+     */
     public function void($fort_id)
     {
         return app(VoidService::class)
@@ -103,6 +110,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws RequestFailed
+     */
     public function checkStatus($fort_id)
     {
         return app(CheckStatusService::class)
@@ -118,6 +128,7 @@ class PayfortIntegration
      * @param string $redirect_url
      * @param array $installments_params
      * @return \TamkeenTech\Payfort\Services\AuthorizePurchaseService
+     * @throws PaymentFailed
      */
     public function purchase(
         array $fort_params,
@@ -146,6 +157,7 @@ class PayfortIntegration
      * @param string $email
      * @param string $redirect_url
      * @return \TamkeenTech\Payfort\Services\AuthorizePurchaseService
+     * @throws PaymentFailed
      */
     public function authorize(
         array $fort_params,
@@ -170,9 +182,9 @@ class PayfortIntegration
      * prepare tokenization params and return array
      * by default it will return a form params.
      *
-     * @param  float  $amount
-     * @param  string  $email
-     * @param  boolean  $form
+     * @param float $amount
+     * @param string $redirect_url
+     * @param bool $form_flag
      * @return array
      */
     public function tokenization(
@@ -189,6 +201,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws PaymentFailed
+     */
     public function processResponse(array $fort_params)
     {
         return app(ProcessResponseService::class)
@@ -198,6 +213,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws RequestFailed
+     */
     public function getInstallmentsPlans()
     {
         return app(GetInstallmentsPlansService::class)
@@ -205,6 +223,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws PaymentFailed
+     */
     public function capture(string $fort_id, $amount)
     {
         return app(CaptureService::class)
@@ -215,6 +236,9 @@ class PayfortIntegration
             ->handle();
     }
 
+    /**
+     * @throws PaymentFailed
+     */
     public function applePay(array $params, float $amount, string $email, string $command = 'PURCHASE')
     {
         return app(ApplePayService::class)

--- a/src/Services/ApplePayService.php
+++ b/src/Services/ApplePayService.php
@@ -4,6 +4,7 @@ namespace TamkeenTech\Payfort\Services;
 
 use Illuminate\Support\Facades\Validator;
 use TamkeenTech\Payfort\Events\PayfortMessageLog;
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
 use TamkeenTech\Payfort\Repositories\Payfort;
 use TamkeenTech\Payfort\Traits\FortParams;
 use TamkeenTech\Payfort\Traits\ResponseHelpers;
@@ -17,6 +18,9 @@ class ApplePayService extends Payfort
 
     protected $command = 'PURCHASE';
 
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         $request = $this->prepareRequest();

--- a/src/Services/AuthorizePurchaseService.php
+++ b/src/Services/AuthorizePurchaseService.php
@@ -4,6 +4,7 @@ namespace TamkeenTech\Payfort\Services;
 
 use Illuminate\Support\Facades\Validator;
 use TamkeenTech\Payfort\Events\PayfortMessageLog;
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
 use TamkeenTech\Payfort\Repositories\Payfort;
 use TamkeenTech\Payfort\Traits\FortParams;
 use TamkeenTech\Payfort\Traits\ResponseHelpers;
@@ -30,6 +31,9 @@ class AuthorizePurchaseService extends Payfort
 
     protected $insallments_params = [];
 
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         // check form params
@@ -111,7 +115,7 @@ class AuthorizePurchaseService extends Payfort
     {
         if (count($params)) {
             // check installments params
-            /** @var \Illuminate\Validation\Validator */
+            /** @var \Illuminate\Validation\Validator $validator */
             $validator = Validator::make($params, [
                 'issuer_code' => 'required|alpha_num|max:8',
                 'plan_code' => 'required|alpha_num|max:8',

--- a/src/Services/CaptureService.php
+++ b/src/Services/CaptureService.php
@@ -2,6 +2,7 @@
 
 namespace TamkeenTech\Payfort\Services;
 
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
 use TamkeenTech\Payfort\Repositories\Payfort;
 use TamkeenTech\Payfort\Traits\FortParams;
 use TamkeenTech\Payfort\Traits\ResponseHelpers;
@@ -10,6 +11,9 @@ class CaptureService extends Payfort
 {
     use ResponseHelpers, FortParams;
 
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         $request = [

--- a/src/Services/CheckStatusService.php
+++ b/src/Services/CheckStatusService.php
@@ -7,6 +7,9 @@ use TamkeenTech\Payfort\Repositories\Payfort;
 
 class CheckStatusService extends Payfort
 {
+    /**
+     * @throws RequestFailed
+     */
     public function handle()
     {
         $request = [

--- a/src/Services/GetInstallmentsPlansService.php
+++ b/src/Services/GetInstallmentsPlansService.php
@@ -7,6 +7,9 @@ use TamkeenTech\Payfort\Repositories\Payfort;
 
 class GetInstallmentsPlansService extends Payfort
 {
+    /**
+     * @throws RequestFailed
+     */
     public function handle()
     {
         $request = [

--- a/src/Services/ProcessResponseService.php
+++ b/src/Services/ProcessResponseService.php
@@ -3,6 +3,7 @@
 namespace TamkeenTech\Payfort\Services;
 
 use TamkeenTech\Payfort\Events\PayfortMessageLog;
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
 use TamkeenTech\Payfort\Repositories\Payfort;
 use TamkeenTech\Payfort\Traits\FortParams;
 use TamkeenTech\Payfort\Traits\ResponseHelpers;
@@ -14,6 +15,9 @@ class ProcessResponseService extends Payfort
 
     protected $fort_params = [];
 
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         $this->validateFortParams();

--- a/src/Services/RefundService.php
+++ b/src/Services/RefundService.php
@@ -7,6 +7,9 @@ use TamkeenTech\Payfort\Repositories\Payfort;
 
 class RefundService extends Payfort
 {
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         $this->isTestingFortId($this->fort_id);

--- a/src/Services/TokenizationService.php
+++ b/src/Services/TokenizationService.php
@@ -56,6 +56,9 @@ class TokenizationService extends Payfort
         return $this;
     }
 
+    /**
+     * @throws PaymentFailed
+     */
     public function setPaymentMethod(string $method): self
     {
         if (! in_array($method, ['cc_merchantpage', 'cc_merchantpage2', 'installments_merchantpage'])) {
@@ -67,7 +70,7 @@ class TokenizationService extends Payfort
         return $this;
     }
 
-    public function getPaymentForm($gatewayUrl, $postData)
+    public function getPaymentForm($gatewayUrl, $postData): string
     {
         $form = '<form style="display:none" name="payfort_payment_form"'
             .' id="payfort_payment_form" method="post" action="'

--- a/src/Services/VoidService.php
+++ b/src/Services/VoidService.php
@@ -7,6 +7,9 @@ use TamkeenTech\Payfort\Repositories\Payfort;
 
 class VoidService extends Payfort
 {
+    /**
+     * @throws PaymentFailed
+     */
     public function handle(): self
     {
         $request = [

--- a/src/Traits/ResponseHelpers.php
+++ b/src/Traits/ResponseHelpers.php
@@ -7,6 +7,7 @@ use TamkeenTech\Payfort\Exceptions\PaymentFailed;
 /**
  * response code
  *
+ * @method array getResponse()
  * @method string getResponseFortId()
  * @method string getResponseReconciliationReference()
  * @method string getResponseAuthorizationCode()
@@ -38,6 +39,10 @@ trait ResponseHelpers
 
     public function __call($name, $args)
     {
+        if ($name === 'getResponse') {
+            return $this->fort_params;
+        }
+
         if (str($name)->startsWith('getResponse')) {
             $key = str($name)->after('getResponse')->snake()->value();
             return $this->fort_params[$key] ?? null;

--- a/src/Traits/ResponseHelpers.php
+++ b/src/Traits/ResponseHelpers.php
@@ -15,6 +15,9 @@ use TamkeenTech\Payfort\Exceptions\PaymentFailed;
  */
 trait ResponseHelpers
 {
+    /**
+     * @throws PaymentFailed
+     */
     protected function validateResponseCode(): self
     {
         if (substr($this->fort_params['response_code'], 2) != '000') {

--- a/tests/ResponseHelpersTest.php
+++ b/tests/ResponseHelpersTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace TamkeenTech\Payfort\Test;
+
+use TamkeenTech\Payfort\Traits\ResponseHelpers;
+use TamkeenTech\Payfort\Exceptions\PaymentFailed;
+use Illuminate\Support\Str;
+
+class ResponseHelpersTest extends TestCase
+{
+    private $responseHelper;
+
+    protected function setUp(): void
+    {
+        // Create a class that uses the ResponseHelpers trait
+        $this->responseHelper = new class {
+            use ResponseHelpers;
+
+            public $fort_params = [];
+
+            // Expose the protected method via a public method for testing
+            public function callValidateResponseCode()
+            {
+                return $this->validateResponseCode();
+            }
+        };
+    }
+
+    /** @test */
+    public function can_validate_response_code_successfully()
+    {
+        $this->responseHelper->fort_params['response_code'] = '02000';
+        $result = $this->responseHelper->callValidateResponseCode();
+        $this->assertSame($this->responseHelper, $result);
+    }
+
+    /** @test */
+    public function can_not_validate_response_code_failure_without_acquirer_code()
+    {
+        $this->expectException(PaymentFailed::class);
+        $this->expectExceptionMessage('02001 - Invalid card');
+
+        $this->responseHelper->fort_params = [
+            'response_code' => '02001',
+            'response_message' => 'Invalid card',
+        ];
+
+        $this->responseHelper->callValidateResponseCode();
+    }
+
+    /** @test */
+    public function can_not_validate_response_code_failure_with_acquirer_code()
+    {
+        $this->expectException(PaymentFailed::class);
+        $this->expectExceptionMessage('1234 - Declined by bank');
+
+        $this->responseHelper->fort_params = [
+            'response_code' => '02001',
+            'response_message' => 'Declined by bank',
+            'acquirer_response_code' => '1234',
+        ];
+
+        $this->responseHelper->callValidateResponseCode();
+    }
+
+    /** @test */
+    public function can_get_response()
+    {
+        $this->responseHelper->fort_params = ['key' => 'value'];
+        $result = $this->responseHelper->getResponse();
+        $this->assertEquals(['key' => 'value'], $result);
+    }
+
+    /** @test */
+    public function can_use_magic_getters()
+    {
+        $this->responseHelper->fort_params = [
+            'fort_id' => '12345',
+            'reconciliation_reference' => 'abcde',
+            'authorization_code' => 'auth123',
+            'merchant_reference' => 'merchant123',
+        ];
+
+        $this->assertEquals('12345', $this->responseHelper->getResponseFortId());
+        $this->assertEquals('abcde', $this->responseHelper->getResponseReconciliationReference());
+        $this->assertEquals('auth123', $this->responseHelper->getResponseAuthorizationCode());
+        $this->assertEquals('merchant123', $this->responseHelper->getResponseMerchantReference());
+    }
+
+    /** @test */
+    public function will_return_null_for_undefined_magic_getter()
+    {
+        $this->responseHelper->fort_params = [];
+        $this->assertNull($this->responseHelper->getResponseUndefinedKey());
+    }
+
+    /** @test */
+    public function can_get_response_payment_method()
+    {
+        $this->responseHelper->fort_params['payment_option'] = 'VISA';
+        $result = $this->responseHelper->getResponsePaymentMethod();
+        $this->assertEquals('VISA', $result);
+    }
+}


### PR DESCRIPTION
We need to allow the library's client to get all fort params in case they need to revalidate them

currently you can't call `Payfort::processResponse` unless it's coming from the request, but what if we needed to validate our call to Payfort

```php
$response = Payfort::authorize(
                    $request->all(),
                    $bill->amount,
                    "foo@ba.r",
                    route('payfort.authorize.callback')
                );
```
currently we can't call `Payfort::processResponse` on `$response`, it's validated inside `Payfort::authorize` but the client could need to revalidate them in another part of the application like in a Service class using `Payfort::processResponse`

for that, I introduced the function `getResponse` in ResponseHelper to retrieve all the fort params



